### PR TITLE
Fixed bugs in the python program

### DIFF
--- a/python/gptmd.py
+++ b/python/gptmd.py
@@ -1,6 +1,7 @@
 # To change this license header, choose License Headers in Project Properties.
 # To change this template file, choose Tools | Templates
 # and open the template in the editor.
+# Changed at 160705, 5:05 PM
 
 __author__ = "Anthony J. Cesnik"
 __date__ = "$Oct 29, 2015 1:25:17 PM$"
@@ -62,7 +63,7 @@ def enter_modification(seq_elements, prot_seq, prot_position, ptm_type):
                             element.addnext(new_feature)
                             break
                         elif element.get('description') > ptm_type:  # Alphabetize new entry.
-                            element.addnext(new_feature)
+                            element.addprevious(new_feature)
                             break
                         break
             break
@@ -79,66 +80,69 @@ def keep_psm(line, ptm_masses):  # So far, there is no fail-safe for blanks line
     precursor_mass_error = float("%.3f" % float(line[18]))
 
     if not is_target or q_value > MIN_FDR_FIRST_PASS: return False
-
-    if equals_within_tolerance(precursor_mass_error, -89.0299, MOD_MASS_TOLERANCE): return True #For Case 1 N-term
-
+    if equals_within_tolerance(precursor_mass_error, -89.0299, MOD_MASS_TOLERANCE): return True  # For Case 1 N-term
     for dm in ptm_masses:
         if equals_within_tolerance(precursor_mass_error, dm, MOD_MASS_TOLERANCE): return True
 
     return False
 
-
 def add_open_search_results(line, sequence_elements, sequences, ptm_types, ptm_masses, nterm_acetyls):
+    global unusedAccessionList, usedAccessionList
+
     line = line.split('\t')
     protein_description, base_peptide_sequence, start_residue = line[13], line[12], int(line[14])
     precursor_mass_error = float("%.3f" % float(line[18]))
     protein_description = protein_description.split('|')
     accession = protein_description[1]
 
-    global unusedAccessionList, usedAccessionList
-
-    if accession in sequences:  # Ensures that the "sequences" dictionary has an entry for the "accession."
-        usedAccessionList.append(accession)
-        protein_sequence = sequences[accession]
-
-        # Case 1 of N-terminal acetylations
-        # is_n_term_acetyl_site_type1 = protein_sequence[0] == 'M' and start_residue == 1 and equals_within_tolerance(precursor_mass_error, -89.029921,MOD_MASS_TOLERANCE)
-        # if is_n_term_acetyl_site_type1:
-        #     base_peptide_sequence = base_peptide_sequence[1:]
-        #     start_residue = 2
-        #     precursor_mass_error = 131.040485 + precursor_mass_error  #Basically cleave the methionine and passes new entry onto acetylation.
-
-        # Case 1 of N-terminal acetylations. The above works as well, and I prefer it. 
-        is_n_term_acetyl_site_type1 = protein_sequence[0] == 'M' and start_residue == 1 and equals_within_tolerance(precursor_mass_error, -89.029921,MOD_MASS_TOLERANCE)
-        if is_n_term_acetyl_site_type1:
-            mod_aa = base_peptide_sequence[1]  # This is the AA after M.
-            if mod_aa in nterm_acetyls:
-                enter_modification(sequence_elements, protein_sequence, 2, nterm_acetyls[mod_aa])  # Acetylate the second AA (after M is cleaved).
-            position_in_peptide = base_peptide_sequence.find('K')
-            while position_in_peptide != -1:
-                enter_modification(sequence_elements, protein_sequence, position_in_peptide+1, "Acetyllysine")
-                position_in_peptide = base_peptide_sequence.find('K', position_in_peptide+1)
-
-        # Case 2 and 3 of N-terminal acetylations
-        is_n_term_acetyl_site_type2 = protein_sequence[0] == 'M' and start_residue in [1,2] and equals_within_tolerance(precursor_mass_error, 42.01, MOD_MASS_TOLERANCE)
-        if is_n_term_acetyl_site_type2:
-            mod_aa = base_peptide_sequence[0]   # Should be Methionine.
-            if mod_aa in nterm_acetyls:
-                enter_modification(sequence_elements, protein_sequence, start_residue, nterm_acetyls[mod_aa])
-
-        # All other modifications handled below.
-        possible_precursor_mass_errors = [deltaM for deltaM in ptm_masses if equals_within_tolerance(precursor_mass_error, deltaM, MOD_MASS_TOLERANCE)]
-        if len(possible_precursor_mass_errors) > 0:
-            for pme in possible_precursor_mass_errors:
-                for ptm_type in ptm_masses[pme]:
-                    for mod_aa in ptm_types[ptm_type]:
-                        position_in_peptide = base_peptide_sequence.find(mod_aa)
-                        while position_in_peptide != -1:
-                            position_in_protein = start_residue + position_in_peptide
-                            enter_modification(sequence_elements, protein_sequence, position_in_protein, ptm_type)
-                            position_in_peptide = base_peptide_sequence.find(mod_aa, position_in_peptide + 1) # Increment the start of the search
-    else:
+    if accession not in sequences:  # Ensures that the "sequences" dictionary has an entry for the "accession."
         unusedAccessionList.append(accession)
+        return
+    if any((AA in set('BXZ')) for AA in sequences[accession]):  # Ensures that a bad amino acid isn't involved.
+        unusedAccessionList.append(accession)
+        # protein_sequence = sequences[accession]
+        # for AA in set('BXZ'):
+        #     print AA
+        # len(protein_sequence.findall('X'))+len(protein_sequence.findall('B'))+len(protein_sequence.findall('Z'))
+        return
+
+    usedAccessionList.append(accession)
+    protein_sequence = sequences[accession]
+
+    # Case 1 of N-terminal acetylations.
+    is_n_term_acetyl_site_type1 = protein_sequence[0] == 'M' and start_residue == 1 and equals_within_tolerance(precursor_mass_error, -89.029921,MOD_MASS_TOLERANCE)
+    if is_n_term_acetyl_site_type1:
+        mod_aa = base_peptide_sequence[1]  # This is the AA after M.
+        if mod_aa in nterm_acetyls:
+            enter_modification(sequence_elements, protein_sequence, 2, nterm_acetyls[mod_aa])  # Acetylate the second AA (after M is cleaved).
+            print "N-term acetylation found for", accession
+        position_in_peptide = base_peptide_sequence.find('K')
+        while position_in_peptide != -1:
+            enter_modification(sequence_elements, protein_sequence, position_in_peptide+1, "Acetyllysine")
+            print "Acetyllysine found for", accession, "at", position_in_peptide
+            position_in_peptide = base_peptide_sequence.find('K', position_in_peptide+1)
+
+    # Case 2 and 3 of N-terminal acetylations
+    is_n_term_acetyl_site_type2 = protein_sequence[0] == 'M' and start_residue in [1,2] and equals_within_tolerance(precursor_mass_error, 42.01, MOD_MASS_TOLERANCE)
+    if is_n_term_acetyl_site_type2:
+        mod_aa = base_peptide_sequence[0]   # Should be Methionine.
+        if mod_aa in nterm_acetyls:
+            enter_modification(sequence_elements, protein_sequence, start_residue, nterm_acetyls[mod_aa])
+        print "N-term acetylation found for", accession
+
+    # All other modifications handled below.
+    possible_precursor_mass_errors = [deltaM for deltaM in ptm_masses if equals_within_tolerance(precursor_mass_error, deltaM, MOD_MASS_TOLERANCE)]
+    if len(possible_precursor_mass_errors) > 0:
+        for pme in possible_precursor_mass_errors:
+            for ptm_type in ptm_masses[pme]:
+                for mod_aa in ptm_types[ptm_type]:
+                    position_in_peptide = base_peptide_sequence.find(mod_aa)
+                    while position_in_peptide != -1:
+                        position_in_protein = start_residue + position_in_peptide
+                        enter_modification(sequence_elements, protein_sequence, position_in_protein, ptm_type)
+                        print ptm_type, "found for", accession, "at", position_in_protein
+                        position_in_peptide = base_peptide_sequence.find(mod_aa, position_in_peptide + 1)  # Increment the start of the search
+
 
 
 def __main__():
@@ -236,13 +240,15 @@ def __main__():
         accession = seq.getparent().find(UP+'accession').text
         sequences[accession] = seq.text.replace('\n','').replace('\r','')
     for i, line in enumerate(psms_list):
-        if i % 1000 == 0: print "psm " + str(i) + " of " + str(len(psms_list))
+        if i % 100 == 0: print "psm " + str(i) + " of " + str(len(psms_list))
         if line.startswith('Filename'): continue
         add_open_search_results(line, sequence_elements, sequences, ptm_types, ptm_masses, nterm_acetyls)
 
-    print len(unusedAccessionList)
-    print "usedAccessionList is: ", usedAccessionList
+    print "Length of unusedAccessionList:", len(unusedAccessionList)
+    print "Length of usedAccessionList:", len(usedAccessionList)
 
+    # print "unusedAccessionList:", unusedAccessionList
+    # print "usedAccessionList:", usedAccessionList
     psms.close()
     # except Exception, e:
     #     print >> sys.stderr, "Failed to open the PSMS.tsv list. %s" % e
@@ -253,13 +259,6 @@ def __main__():
     outF.close()
 
     end = time.time()
-    print end - start
-
-# total = 0
-# for i in range(100):
-#     if __name__ == "__main__" : __main__()
-#     total = total + end - start
-#     average = total/(i+1)
-# print average
+    print "Time:", end - start
 
 if __name__ == "__main__" : __main__()


### PR DESCRIPTION
Fixed logic (indexing of position in peptide) in add_open_search_results function.  Fixed duplicate entry of modifications in the enter_modification function. Separated N-term acetylation from the other modifications.  Added iterative parsing of the uniprot-xml database.  Managed B,X, Z amino acids by adjusting start_residue to correspond to the database position in the protein sequence.  This is in response to Craig's Morpheus Search, which deletes B,X, and Z amino acids and then enumerates the residues causing a discrepancy between the start_residue value given on a PSMs line and the position of that peptide in the database sequence.    